### PR TITLE
fix(card_transition): Better left-slide return transition

### DIFF
--- a/examples/card_transition/components/card/card.js
+++ b/examples/card_transition/components/card/card.js
@@ -61,12 +61,13 @@ Component({
         () => {
           'worklet'
           return {
+            opacity: this.opacity.value,
             borderTopRightRadius: this.radius.value, // 不带单位默认是 px
             borderTopLeftRadius: this.radius.value,
           }
         },
         {
-          immediate: true,
+          immediate: false,
           flush: 'sync'
         },
         () => {}, 


### PR DESCRIPTION
fix #7 , Add an `opacity` transition to the picture. It seems to be much better than not adding it.
Looking forward to your reply. 🙏

https://github.com/user-attachments/assets/dc923ca7-0b23-4f7c-80d3-bfb01fc04821

https://github.com/user-attachments/assets/643dc946-c2ad-4bab-8c60-7251ba95fea0
